### PR TITLE
Gradle Configuration Updates for Dependency Injection and Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Project Overview 
 
-- Utilized: Kotlin, Hilt
+- Utilized: Kotlin, Hilt, MVI, Orbit, Jetpack Compose 
 
 -----
 ## Milestones
@@ -25,7 +25,7 @@
     - Transitioned from localDataSource to userLocalDataSource : This change isolates data management to specific views, thereby decluttering activities and improving code clarity.
   - **Dependency Management with LoginContainer** - [commit 3b5f3a4](https://github.com/ld5ehom/sns-android/commit/3b5f3a4cde05dfb8441d9aeac6a2c3a20f83e61f)
     - Implemented a new LoginContainer : Focuses on managing dependencies exclusively for login functionalities, which enhances resource efficiency and streamlines dependency management.
-  - **Hilt Gradle Plugin Setup**
+  - **Hilt Gradle Plugin Setup** - [commit a0bb0ff](https://github.com/ld5ehom/sns-android/commit/a0bb0ffbbeb2ec548b3a3d13e6be78e15c5a507a)
     - Set up Hilt for dependency injection
       - Added Hilt Gradle plugin and related libraries in build.gradle 
       - Configured Hilt for dependency injection
@@ -46,6 +46,11 @@
       - Domain: No external dependencies (Core module) 
       - Presentation: Depends on Domain module
       - Data: Depends on Domain module  
+  - **Gradle Configuration Updates for Dependency Injection and Compatibility**
+    - Added kotlin-kapt to enable annotation processing for Kotlin.(build.gradle.kts(project: sns-android))
+    - Integrated it with Hilt for dependency injection and configured kapt to correct error types during compilation.
+    - The Gradle file for the Presentation module(build.gradle.kts(Module: presentation)) was updated to include Hilt for dependency injection and enable Jetpack Compose. 
+    - Kotlin and Java 17 compatibility were configured, and the Domain module was added as a dependency.
 
 -----
 ## Progress Tracking

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.kotlin.serialization)
     id("kotlin-kapt")  // kapt
-    id("com.google.dagger.hilt.android") // Hilt
+    alias(libs.plugins.hilt) // Hilt
 }
 
 android {
@@ -89,7 +89,7 @@ dependencies {
     implementation(libs.okhttp)
 
     // Hilt
-    implementation("com.google.dagger:hilt-android:2.48.1")
-    kapt("com.google.dagger:hilt-android-compiler:2.48.1")
+    implementation(libs.hilt)
+    kapt(libs.hilt.compiler)
 
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,7 +18,7 @@
 plugins {
     alias(libs.plugins.com.android.application) apply false
     alias(libs.plugins.org.jetbrains.kotlin.android) apply false
-    id("com.google.dagger.hilt.android") version "2.48.1" apply false
+    alias(libs.plugins.hilt) apply false
     alias(libs.plugins.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.android.library) apply false
 }

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+    alias(libs.plugins.hilt)
+    id("kotlin-kapt")
+    alias(libs.plugins.kotlin.serialization)
 }
 
 android {
@@ -43,4 +46,8 @@ dependencies {
 
     // domain
     implementation(project(":domain"))
+
+    // hilt
+    implementation(libs.hilt)
+    kapt(libs.hilt.compiler)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,11 @@ retrofit = "2.9.0"
 jetbrains-kotlin-jvm = "1.8.10"
 appcompat = "1.7.0"
 material = "1.12.0"
+hilt = "2.48.1"
+orbit = "6.1.0"
+coil = "2.3.0"
+paging = "3.2.1"
+coroutines-core = "1.3.2"
 
 [libraries]
 core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "core-ktx" }
@@ -28,6 +33,7 @@ ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview
 ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
 material3 = { group = "androidx.compose.material3", name = "material3" }
+navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version = "2.5.3"}
 
 datastore = { module = "androidx.datastore:datastore-preferences", version = "1.0.0" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
@@ -36,6 +42,21 @@ okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version = "4.12.0"}
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version = "1.5.0"}
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
+hilt = { group = "com.google.dagger", name = "hilt-android", version.ref = "hilt" }
+hilt-compiler = { group = "com.google.dagger", name = "hilt-android-compiler", version.ref = "hilt" }
+hilt-navigation-compose = { group = "androidx.hilt" , name = "hilt-navigation-compose", version = "1.0.0"}
+orbit-core = { group = "org.orbit-mvi", name = "orbit-core", version.ref = "orbit"}
+orbit-viewmodel = { group = "org.orbit-mvi", name = "orbit-viewmodel", version.ref = "orbit"}
+orbit-compose = { group = "org.orbit-mvi", name = "orbit-compose", version.ref = "orbit"}
+splash = { group = "androidx.core", name = "core-splashscreen", version = "1.0.1" }
+coil = { group = "io.coil-kt", name = "coil", version.ref = "coil"}
+coil-compose = { group = "io.coil-kt", name = "coil-compose", version.ref = "coil"}
+paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging"}
+paging-common = {group = "androidx.paging", name = "paging-common", version.ref = "paging"}
+paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging"}
+
+coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref="coroutines-core"}
+
 
 [plugins]
 com-android-application = { id = "com.android.application", version.ref = "agp" }
@@ -43,6 +64,9 @@ org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.re
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "org-jetbrains-kotlin-android" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "jetbrains-kotlin-jvm" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+
+hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt"}
+kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version = "1.8.10"}
 
 [bundles]
 

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -1,6 +1,8 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
+    id("kotlin-kapt")
+    alias(libs.plugins.hilt)
 }
 
 android {
@@ -30,16 +32,39 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
+
+    // Enabled Jetpack Compose (Jetpack Compose 활성화)
+    buildFeatures{
+        compose = true
+    }
+    composeOptions{
+        kotlinCompilerExtensionVersion = "1.4.3"
+    }
 }
 
 dependencies {
 
-    implementation(libs.core.ktx)
     implementation(libs.androidx.appcompat)
-    implementation(libs.material)
+    implementation(libs.core.ktx)
+    implementation(libs.lifecycle.runtime.ktx)
+    implementation(libs.activity.compose)
+    implementation(platform(libs.compose.bom))
+    implementation(libs.ui)
+    implementation(libs.ui.graphics)
+    implementation(libs.ui.tooling.preview)
+    implementation(libs.material3)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)
+
+    androidTestImplementation(platform(libs.compose.bom))
+    androidTestImplementation(libs.ui.test.junit4)
+    debugImplementation(libs.ui.tooling)
+    debugImplementation(libs.ui.test.manifest)
+
+    // hilt
+    implementation(libs.hilt)
+    kapt(libs.hilt.compiler)
 
     implementation(project(":domain"))
 }


### PR DESCRIPTION
    - Added kotlin-kapt to enable annotation processing for Kotlin.(build.gradle.kts(project: sns-android))
    - Integrated it with Hilt for dependency injection and configured kapt to correct error types during compilation.
    - The Gradle file for the Presentation module(build.gradle.kts(Module: presentation)) was updated to include Hilt for dependency injection and enable Jetpack Compose.
    - Kotlin and Java 17 compatibility were configured, and the Domain module was added as a dependency.