### PR TITLE
LoginViewModel Refactoring and Error Fixes with Dagger and Orbit MVI

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@
       - Implemented custom FCButton and CustomButton components with configurable text and click actions, allowing them to be reused across the app's UI.
     - presentation/Components/TextFields
       - Built reusable CustomTextField components for user input, which are used in both the login and sign-up screens to handle input for ID, username, and passwords.
-  - **Login Flow Update with Hilt and Navigation Component(presentation)**
+  - **Login Flow Update with Hilt and Navigation Component(presentation)** - [commit 5b702af](https://github.com/ld5ehom/sns-android/commit/5b702af4ce9659030e6f86972d5e7ed079a64d56)
     - Organizing Login Flow with Hilt and Navigation Compose
       - Since the login process is part of a single context, the navigation component was used to group it into one flow. Hilt and Navigation Compose were integrated to manage dependencies and navigation within the login flow.
     - Added Navigation and Hilt Integration (gradle : presentation)
@@ -87,6 +87,22 @@
       - LoginActivity sets up the login UI using Jetpack Compose, applies the SNSTheme, and manages navigation between login-related screens (WelcomeScreen, LoginScreen, and SignUpScreen) via LoginNavHost for a cohesive login flow.
     - LoginViewModel with Hilt and Coroutines
       - The LoginViewModel handles the login logic using Hilt for dependency injection. It integrates the LoginUseCase to manage the login process, and uses viewModelScope to launch coroutines, ensuring that login operations are performed asynchronously when the user clicks the login button.
+  - **LoginViewModel Refactoring and Error Fixes with Dagger and Orbit MVI**
+    - Error : Dagger Missing binding 
+      - The Login ViewModel requested the LoginUseCase, but the LoginUseCase implementation was not bound to the Hilt graph, causing an error.
+      - To resolve this, the LoginUseCaseImpl was bound in the data module, considering the login functionality.
+    - Error : LoginActivity Implement interface dagger.hilt 
+      - The error occurred in presentation/login/LoginActivity requiring the implementation of a Dagger Hilt interface.
+      - Added @AndroidEntryPoint to LoginActivity.
+    - data/usecase/LoginUseCaseImpl 
+      - LoginUseCaseImpl uses Dagger's @Inject for dependency injection, and the invoke function returns a token within a result.
+    - Refactoring LoginViewModel with Orbit MVI and State Management
+      - The LoginViewModel has been refactored to enhance state management and handle side effects more effectively using the Orbit MVI (Model-View-Intent) pattern. This update improves the structure of the login feature by managing user input, login logic, and error handling in a clearer and more maintainable way.
+      - Integrated Orbit MVI Pattern: LoginViewModel now implements ContainerHost to manage login state (LoginState) and side effects (LoginSideEffect), providing clear state management.
+      - Added LoginState: LoginState now holds the login credentials (ID, password), enabling cleaner and more predictable state updates.
+      - Introduced Side Effect Handling: LoginSideEffect manages UI-related actions like showing toast messages, keeping business logic separate from the UI.
+      - Improved Error Handling: A CoroutineExceptionHandler now handles login errors, showing error messages via side effects.
+      - Input Handling Updates: Added onIdChange and onPasswordChange to update state when user input changes.
 
 
 **Task 2. Profile Page**

--- a/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
@@ -1,0 +1,20 @@
+package com.ld5ehom.data.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import com.ld5ehom.data.usecase.LoginUseCaseImpl
+import com.ld5ehom.domain.usecase.login.LoginUseCase
+
+@Module
+@InstallIn(SingletonComponent::class)
+// This module will be installed in the SingletonComponent, making its bindings available application-wide
+// (이 모듈은 SingletonComponent에 설치되어 앱 전역에서 바인딩된 의존성을 사용할 수 있음)
+abstract class UserModule {
+
+    @Binds
+    // Binds LoginUseCaseImpl to the LoginUseCase interface
+    // (LoginUseCaseImpl을 LoginUseCase 인터페이스에 바인딩)
+    abstract fun bindLoginUseCase(uc: LoginUseCaseImpl): LoginUseCase
+}

--- a/data/src/main/java/com/ld5ehom/data/usecase/LoginUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/LoginUseCaseImpl.kt
@@ -1,0 +1,12 @@
+package com.ld5ehom.data.usecase
+
+import com.ld5ehom.domain.usecase.login.LoginUseCase
+import javax.inject.Inject
+
+// This constructor is annotated with @Inject to enable dependency injection using Dagger
+// (Dagger를 통해 의존성을 주입받기 위해 @Inject로 표시된 생성자)
+class LoginUseCaseImpl @Inject constructor() : LoginUseCase {
+    override suspend fun invoke(id: String, password: String): Result<String> = kotlin.runCatching {
+        "token"
+    }
+}

--- a/presentation/build.gradle.kts
+++ b/presentation/build.gradle.kts
@@ -70,5 +70,10 @@ dependencies {
     implementation(libs.navigation.compose)
     implementation(libs.hilt.navigation.compose)
 
+    // orbit
+    implementation(libs.orbit.core)
+    implementation(libs.orbit.compose)
+    implementation(libs.orbit.viewmodel)
+
     implementation(project(":domain"))
 }

--- a/presentation/src/main/java/com/ld5ehom/presentation/login/LoginActivity.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/login/LoginActivity.kt
@@ -4,9 +4,11 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import com.ld5ehom.presentation.theme.SNSTheme
+import dagger.hilt.android.AndroidEntryPoint
 
 // LoginActivity class that sets up the login UI
 // 로그인 UI를 설정하는 LoginActivity 클래스
+@AndroidEntryPoint
 class LoginActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/presentation/src/main/java/com/ld5ehom/presentation/login/LoginViewModel.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/login/LoginViewModel.kt
@@ -1,28 +1,73 @@
 package com.ld5ehom.presentation.login
 
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.CoroutineExceptionHandler
 import com.ld5ehom.domain.usecase.login.LoginUseCase
+import org.orbitmvi.orbit.Container
+import org.orbitmvi.orbit.ContainerHost
+import org.orbitmvi.orbit.syntax.simple.intent
+import org.orbitmvi.orbit.syntax.simple.postSideEffect
+import org.orbitmvi.orbit.syntax.simple.reduce
+import org.orbitmvi.orbit.viewmodel.container
+import javax.annotation.concurrent.Immutable
 import javax.inject.Inject
 
 @HiltViewModel
-// ViewModel class that handles login logic with Hilt for dependency injection
-// Hilt로 의존성 주입을 받아 로그인 로직을 처리하는 ViewModel 클래스
+// ViewModel class that handles login logic using Orbit MVI for state management and side effects
+// Orbit MVI를 사용해 상태 관리 및 부수 효과를 처리하는 ViewModel 클래스
 class LoginViewModel @Inject constructor(
-    private val loginUseCase: LoginUseCase
-) : ViewModel(){
+    private val loginUseCase: LoginUseCase  // LoginUseCase is injected to handle login logic (로그인 로직을 처리하기 위해 LoginUseCase가 주입됨)
+) : ViewModel(), ContainerHost<LoginState, LoginSideEffect> {
 
-    // Function called when the login button is clicked  (로그인 버튼이 클릭되었을 때 호출되는 함수)
-    fun onLoginClick(){
-        val id = ""
-        val password = ""
+    // Orbit container that manages the LoginState and handles side effects
+    // Orbit container가 로그인 상태를 관리하고 부수 효과를 처리
+    override val container: Container<LoginState, LoginSideEffect> = container(
+        initialState = LoginState(),
+        buildSettings = {
+            this.exceptionHandler = CoroutineExceptionHandler { _, throwable ->
+                // Handle any exceptions by posting a side effect with an error message (예외가 발생하면 에러 메시지와 함께 부수 효과를 게시함)
+                intent {
+                    postSideEffect(LoginSideEffect.Toast(message = throwable.message.orEmpty()))
+                }
+            }
+        }
+    )
 
-        // Launch a coroutine within the ViewModel's scope to handle login asynchronously
-        // ViewModel의 범위 내에서 코루틴을 실행하여 비동기적으로 로그인 처리
-        viewModelScope.launch {
-            loginUseCase(id, password)
+    // Function called when login button is clicked, executing the login use case
+    // 로그인 버튼 클릭 시 호출되는 함수로, 로그인 유즈케이스를 실행
+    fun onLoginClick() = intent {
+        val id = state.id
+        val password = state.password
+        val token = loginUseCase(id, password).getOrThrow()  // Perform login and get the token
+        postSideEffect(LoginSideEffect.Toast(message = "token = $token"))  // Show token in a toast message
+    }
+
+    // Update the state when the id input changes (id 입력이 변경될 때 상태 업데이트)
+    fun onIdChange(id: String) = intent {
+        reduce {
+            state.copy(id = id)  // Create a new state with the updated id
         }
     }
+
+    // Update the state when the password input changes (비밀번호 입력이 변경될 때 상태 업데이트)
+    fun onPasswordChange(password: String) = intent {
+        reduce {
+            state.copy(password = password)  // Create a new state with the updated password
+        }
+    }
+}
+
+// Immutable state class to hold the login state (id, password)
+// 로그인 상태(id, 비밀번호)를 저장하는 불변 상태 클래스
+@Immutable
+data class LoginState(
+    val id: String = "",
+    val password: String = ""
+)
+
+// Interface for handling side effects, such as showing toast messages
+// 부수 효과를 처리하는 인터페이스, Such as: 토스트 메시지 표시
+sealed interface LoginSideEffect {
+    class Toast(val message: String) : LoginSideEffect
 }


### PR DESCRIPTION
    - Error : Dagger Missing binding - The Login ViewModel requested the LoginUseCase, but the LoginUseCase implementation was not bound to the Hilt graph, causing an error. - To resolve this, the LoginUseCaseImpl was bound in the data module, considering the login functionality.
    - Error : LoginActivity Implement interface dagger.hilt
      - The error occurred in presentation/login/LoginActivity requiring the implementation of a Dagger Hilt interface.
      - Added @AndroidEntryPoint to LoginActivity.
    - data/usecase/LoginUseCaseImpl - LoginUseCaseImpl uses Dagger's @Inject for dependency injection, and the invoke function returns a token within a result.
    - Refactoring LoginViewModel with Orbit MVI and State Management
      - The LoginViewModel has been refactored to enhance state management and handle side effects more effectively using the Orbit MVI (Model-View-Intent) pattern. This update improves the structure of the login feature by managing user input, login logic, and error handling in a clearer and more maintainable way.
      - Integrated Orbit MVI Pattern: LoginViewModel now implements ContainerHost to manage login state (LoginState) and side effects (LoginSideEffect), providing clear state management. - Added LoginState: LoginState now holds the login credentials (ID, password), enabling cleaner and more predictable state updates. - Introduced Side Effect Handling: LoginSideEffect manages UI-related actions like showing toast messages, keeping business logic separate from the UI. - Improved Error Handling: A CoroutineExceptionHandler now handles login errors, showing error messages via side effects. - Input Handling Updates: Added onIdChange and onPasswordChange to update state when user input changes.