### PR TITLE
Login API Request Handling: Data Model and Use Case Implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,8 @@
       - Introduced Side Effect Handling: LoginSideEffect manages UI-related actions like showing toast messages, keeping business logic separate from the UI.
       - Improved Error Handling: A CoroutineExceptionHandler now handles login errors, showing error messages via side effects.
       - Input Handling Updates: Added onIdChange and onPasswordChange to update state when user input changes.
-  - **Login Feature Updates: Password Masking, Orbit MVI Integration, and Retrofit Setup** - [commit 13f4a3e](https://github.com/ld5ehom/sns-android/commit/13f4a3e1e5d607da72b734bdc1905d40562784ac)
+  - **Login Feature Updates: Password Masking, Orbit MVI Integration, and Retrofit Setup** 
+  - [commit 13f4a3e](https://github.com/ld5ehom/sns-android/commit/13f4a3e1e5d607da72b734bdc1905d40562784ac)
     - CustomTextField Update for Password Masking
       - Password Masking Added: visualTransformation was added to hide text input for password fields using PasswordVisualTransformation.
     - Enhancements in LoginScreen with Orbit MVI Integration
@@ -114,21 +115,25 @@
     - RetrofitModule: Integrated OkHttpClient and JSON Converter for API Requests
       - OkHttpClient: Provides an OkHttpClient instance bound to the Dagger dependency graph to handle network requests. 
       - Retrofit Configuration: Configures Retrofit with kotlinx.serialization for JSON conversion, ignoring unknown keys during deserialization for flexibility. The API's base URL is set to the ld5ehom_HOST, and the OkHttpClient is attached for managing HTTP requests.
-  - **Standardized API Interaction with Retrofit and CommonResponse**
+  - **Standardized API Interaction with Retrofit and CommonResponse** - [commit 8d015e8](https://github.com/ld5ehom/sns-android/commit/8d015e824489c5c7d59414148dda680e31735871)
     - data/retrofit/UserService 
       - An interface that defines network requests using Retrofit for handling API calls (Post, Get methods, etc.).
     - data/model/CommonResponse
       - CommonResponse is a generic data class in data/model used to standardize API responses. It includes fields for result status, data, and error details to ensure consistent handling of API responses.
     - RetrofitModule Update: Providing UserService for API Calls
       - UserService Update: An update was made in RetrofitModule to provide an instance of UserService using Retrofit. This allows UserService to be injected and utilized across the application for making API requests.
+  - **Login API Request Handling: Data Model and Use Case Implementation**
+    - data/model/LoginParam
+      - The LoginParam class is a data model used to store the login credentials (loginId and password) for API requests. It includes a method toRequestBody() that converts the LoginParam object into a JSON-formatted RequestBody, which is required for making login API requests.
+    - LoginUseCaseImpl Implementation with Dagger for API Integration
+      - LoginUseCaseImpl leverages Dagger's @Inject for dependency injection, automatically providing UserService to handle login API calls. The invoke function converts user credentials into a request body, calls the login API, and safely handles the response using Kotlin’s runCatching.
 
 
 
+**Task 2. Sign Up Page**
+- **Issues** : [task-2-signup](https://github.com/ld5ehom/sns-android/tree/task-2-signup)
 
-**Task 2. Sign Up**
-- **Issues** :
-
-**Task 3. Logout**
+**Task 3. Logout Page**
 - **Issues** :
 
 **Task 4. Profile Page**

--- a/data/src/main/java/com/ld5ehom/data/model/LoginParam.kt
+++ b/data/src/main/java/com/ld5ehom/data/model/LoginParam.kt
@@ -1,0 +1,22 @@
+package com.ld5ehom.data.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+@Serializable
+// Data class representing login parameters
+// (로그인 시 필요한 파라미터를 나타내는 데이터 클래스)
+data class LoginParam(
+    val loginId: String,
+    val password: String
+) {
+
+    // Converts the LoginParam object to a JSON RequestBody for API calls
+    // (LoginParam 객체를 JSON 형식으로 변환하여 API 요청 본문으로 사용)
+    fun toRequestBody(): RequestBody {
+        return Json.encodeToString(this).toRequestBody()  // Serializes the object to JSON and converts it to RequestBody
+    }
+}

--- a/data/src/main/java/com/ld5ehom/data/retrofit/UserService.kt
+++ b/data/src/main/java/com/ld5ehom/data/retrofit/UserService.kt
@@ -9,7 +9,7 @@ import retrofit2.http.POST
 interface UserService {
 
     @POST("users/login")
-    @Headers("Content-Type:application/json; charset=UTF8")
+    @Headers("Content-Type:application/json; charset=UTF8") // HTTP 500 error
     suspend fun login(
         @Body requestBody: RequestBody  // parameter
     ):CommonResponse<String>

--- a/data/src/main/java/com/ld5ehom/data/usecase/LoginUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/LoginUseCaseImpl.kt
@@ -1,12 +1,24 @@
 package com.ld5ehom.data.usecase
 
+import com.ld5ehom.data.model.LoginParam
+import com.ld5ehom.data.retrofit.UserService
 import com.ld5ehom.domain.usecase.login.LoginUseCase
 import javax.inject.Inject
 
 // This constructor is annotated with @Inject to enable dependency injection using Dagger
 // (Dagger를 통해 의존성을 주입받기 위해 @Inject로 표시된 생성자)
-class LoginUseCaseImpl @Inject constructor() : LoginUseCase {
+class LoginUseCaseImpl @Inject constructor(
+    private val userService: UserService,  // Injected UserService to handle login API calls (로그인 API 호출을 처리하는 UserService를 주입받음)
+) : LoginUseCase {
+    // Function that performs login by calling the API with user credentials
+    // (사용자 자격 증명을 전달해 로그인 API를 호출하는 함수)
     override suspend fun invoke(id: String, password: String): Result<String> = kotlin.runCatching {
-        "token"
+        // Convert id and password into a request body for the login API
+        // (id와 password를 로그인 API 요청 본문으로 변환)
+        val requestBody = LoginParam(loginId = id, password = password).toRequestBody()
+        // Call the login API and retrieve the response data
+        // (로그인 API 호출 후 응답 데이터 획득)
+        userService.login(requestBody = requestBody).data
     }
 }
+


### PR DESCRIPTION
- data/model/LoginParam 
    - The LoginParam class is a data model used to store the login credentials (loginId and password) for API requests. It includes a method toRequestBody() that converts the LoginParam object into a JSON-formatted RequestBody, which is required for making login API requests.
- LoginUseCaseImpl Implementation with Dagger for API Integration
      - LoginUseCaseImpl leverages Dagger's @Inject for dependency injection, automatically providing UserService to handle login API calls. The invoke function converts user credentials into a request body, calls the login API, and safely handles the response using Kotlin’s runCatching.