### PR TITLE
SplashActivity and Dagger Updates: Token Handling, Navigation, and Co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@
       - It includes a toRequestBody function to convert the data into a JSON-formatted RequestBody for the API request.
     - data/UserModule Update
       - Binds SignUpUseCaseImpl to the SignUpUseCase interface
-  - **Sign-Up Process Updates: State Management, Token Handling, and Navigation**
+  - **Sign-Up Process Updates: State Management, Token Handling, and Navigation** - [commit a4cbd54](https://github.com/ld5ehom/sns-android/commit/a4cbd5444b44fb52301031356641f7451afaaa02)
     - LoginViewModel and SignUpViewModel blockingIntent Update 
       - Switched from intent to blockingIntent for handling state updates in text input fields to prevent errors and delays during rapid input. 
       - This ensures immediate and synchronous state updates, improving user experience and input handling in the application.
@@ -171,8 +171,20 @@
       - build.gradle(data) : Added datastore dependency to the project in Gradle using implementation.
       - UserDataStore provides methods to manage the user's authentication token in Android's DataStore. 
       - It includes setToken for saving the token, getToken for retrieving it, and clear for removing all stored data.
-
-
+  - **SplashActivity and Dagger Updates: Token Handling, Navigation, and Context Binding**
+    - SplashActivity: Token Check and Navigation Based on Login Status
+      - The SplashActivity checks the user's login status by retrieving the token via GetTokenUseCase. 
+      - If a token exists, it navigates to the MainActivity. If not, it directs the user to the LoginActivity. 
+      - The activity uses Intent flags (FLAG_ACTIVITY_CLEAR_TASK and FLAG_ACTIVITY_NEW_TASK) to clear the task stack and prevent returning to the splash screen.
+    - SplashActivity: Set as Main Entry Point in Android Manifest
+      - Added SplashActivity to the AndroidManifest.xml file as the main entry point of the application. 
+      - The intent filter with MAIN action and LAUNCHER category ensures that this activity is launched when the app is opened.
+    - Dagger/MissingBinding Error : Binding Token UseCase Implementations to Interfaces with Dagger
+      - Added bindings for the token-related use cases (GetTokenUseCaseImpl, SetTokenUseCaseImpl, and ClearTokenUseCaseImpl) to their corresponding interfaces in the Dagger dependency graph using @Binds. 
+      - This ensures that the correct implementations are injected wherever the use case interfaces are required.
+    - Dagger/MissingBinding Error -> AppModule: Binding Application Context for Dependency Injection
+      - The AppModule class provides the Application context by binding the Application instance to the Context interface. 
+      - This setup allows Dagger Hilt to inject the application context wherever the Context type is required within the application.
 
 **Task 3. Logout Page**
 - **Issues** :

--- a/app/src/main/java/com/ld5ehom/sns_android/AppModule.kt
+++ b/app/src/main/java/com/ld5ehom/sns_android/AppModule.kt
@@ -1,0 +1,20 @@
+package com.ld5ehom.sns_android
+
+import android.app.Application
+import android.content.Context
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+
+@Module
+@InstallIn(SingletonComponent::class)
+// AppModule provides application-level dependencies
+// (AppModule은 애플리케이션 수준의 의존성을 제공)
+abstract class AppModule {
+
+    @Binds
+    // Binds the Application instance to the Context interface for dependency injection
+    // (Application 인스턴스를 Context 인터페이스에 바인딩하여 의존성 주입에 사용)
+    abstract fun bindContext(application: Application): Context
+}

--- a/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
@@ -4,10 +4,17 @@ import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
+import com.ld5ehom.data.usecase.ClearTokenUseCaseImpl
+import com.ld5ehom.data.usecase.GetTokenUseCaseImpl
 import com.ld5ehom.data.usecase.LoginUseCaseImpl
+import com.ld5ehom.data.usecase.SetTokenUseCaseImpl
 import com.ld5ehom.data.usecase.SignUpUseCaseImpl
+import com.ld5ehom.domain.usecase.login.ClearTokenUseCase
+import com.ld5ehom.domain.usecase.login.GetTokenUseCase
 import com.ld5ehom.domain.usecase.login.LoginUseCase
 import com.ld5ehom.domain.usecase.login.SignUpUseCase
+import com.ld5ehom.domain.usecase.login.SetTokenUseCase
+
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -23,5 +30,20 @@ abstract class UserModule {
     @Binds
     // Binds SignUpUseCaseImpl to the SignUpUseCase interface
     abstract fun bindSignUpUseCase(uc: SignUpUseCaseImpl):SignUpUseCase
+
+    @Binds
+    // Binds GetTokenUseCaseImpl implementation to the GetTokenUseCase interface
+    // (GetTokenUseCase 인터페이스에 GetTokenUseCaseImpl 구현체를 바인딩)
+    abstract fun bindGetTokenUseCase(uc: GetTokenUseCaseImpl): GetTokenUseCase
+
+    @Binds
+    // Binds SetTokenUseCaseImpl implementation to the SetTokenUseCase interface
+    // (SetTokenUseCase 인터페이스에 SetTokenUseCaseImpl 구현체를 바인딩)
+    abstract fun bindSetTokenUseCase(uc: SetTokenUseCaseImpl): SetTokenUseCase
+
+    @Binds
+    // Binds ClearTokenUseCaseImpl implementation to the ClearTokenUseCase interface
+    // (ClearTokenUseCase 인터페이스에 ClearTokenUseCaseImpl 구현체를 바인딩)
+    abstract fun bindClearTokenUseCase(uc: ClearTokenUseCaseImpl): ClearTokenUseCase
 
 }

--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
-        <!-- Declares the LoginActivity in the application -->
-        <!-- LoginActivity를 애플리케이션 내에서 선언 -->
-        <activity android:name=".login.LoginActivity"
+        <!-- Declares this activity as the main entry point of the app -->
+        <!-- 이 액티비티를 앱의 메인 진입점으로 선언 -->
+        <activity android:name=".login.LoginActivity" />
+
+        <!-- Specifies that this activity appears in the app launcher -->
+        <!-- 이 액티비티가 앱 실행기(런처)에 표시되도록 설정 -->
+        <activity android:name=".MainActivity" />
+        <activity
+                android:name=".SplashActivity"
                 android:exported="true">
 
             <!-- This activity is exported, allowing other apps to interact with it -->
@@ -18,6 +24,5 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".MainActivity"/>
     </application>
 </manifest>

--- a/presentation/src/main/java/com/ld5ehom/presentation/SplashActivity.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/SplashActivity.kt
@@ -1,0 +1,49 @@
+package com.ld5ehom.presentation
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import com.ld5ehom.domain.usecase.login.GetTokenUseCase
+import com.ld5ehom.presentation.login.LoginActivity
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class SplashActivity : AppCompatActivity() {
+
+    // Injects GetTokenUseCase to handle token retrieval
+    // (토큰 검색을 처리하기 위한 GetTokenUseCase 주입)
+    @Inject
+    lateinit var getTokenUseCase: GetTokenUseCase
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // Launches a coroutine in the lifecycle scope to check the login status (로그인 상태를 확인하기 위한 코루틴 실행)
+        lifecycleScope.launch {
+            val isLoggedIn = !getTokenUseCase().isNullOrEmpty()  // Checks if the token exists
+
+            if (isLoggedIn) {
+                // If the user is logged in, navigate to the MainActivity (로그인된 경우 MainActivity로 이동)
+                startActivity(
+                    Intent(
+                        this@SplashActivity, MainActivity::class.java
+                    ).apply {
+                        flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK  // Clear the task stack and start MainActivity (백스택을 지우고 MainActivity 시작)
+                    }
+                )
+            } else {
+                // If the user is not logged in, navigate to the LoginActivity (로그인되지 않은 경우 LoginActivity로 이동)
+                startActivity(
+                    Intent(
+                        this@SplashActivity, LoginActivity::class.java
+                    ).apply {
+                        flags = Intent.FLAG_ACTIVITY_CLEAR_TASK or Intent.FLAG_ACTIVITY_NEW_TASK  // Clear the task stack and start LoginActivity (백스택을 지우고 LoginActivity 시작)
+                    }
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
- SplashActivity: Token Check and Navigation Based on Login Status 
    - The SplashActivity checks the user's login status by retrieving the token via GetTokenUseCase. 
    - If a token exists, it navigates to the MainActivity. If not, it directs the user to the LoginActivity. 
    - The activity uses Intent flags (FLAG_ACTIVITY_CLEAR_TASK and FLAG_ACTIVITY_NEW_TASK) to clear the task stack and prevent returning to the splash screen.
- SplashActivity: Set as Main Entry Point in Android Manifest 
    - Added SplashActivity to the AndroidManifest.xml file as the main entry point of the application. 
    - The intent filter with MAIN action and LAUNCHER category ensures that this activity is launched when the app is opened.
- Dagger/MissingBinding Error : Binding Token UseCase Implementations to Interfaces with Dagger
    - Added bindings for the token-related use cases (GetTokenUseCaseImpl, SetTokenUseCaseImpl, and ClearTokenUseCaseImpl) to their corresponding interfaces in the Dagger dependency graph using @Binds.
    - This ensures that the correct implementations are injected wherever the use case interfaces are required.
- Dagger/MissingBinding Error -> AppModule: Binding Application Context for Dependency Injection 
    - The AppModule class provides the Application context by binding the Application instance to the Context interface. 
    - This setup allows Dagger Hilt to inject the application context wherever the Context type is required within the application.