### PR TITLE
Retrofit Integration with Custom Interceptor for Token Management and…

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@
     - MainRoute Enum Update: Renaming Routes and Descriptions
       - The MainRoute enum was updated to reflect changes in route names and descriptions.
       - The corresponding routes and content descriptions were updated to "HomeScreen" (Post List), "PostScreen" (Create Post), and "ProfileScreen" (My Profile), aligning with the new functionality and navigation structure.
-  - **Profile Screen UI and ViewModel Updates** 
+  - **Profile Screen UI and ViewModel Updates** - [48e052b](https://github.com/ld5ehom/sns-android/commit/48e052b73a4a86f4217b901ee3ea417ec3a2730b)
     - Profile Screen UI
       - Profile Screen UI and Logic: Implements a screen for managing user profile settings such as username, profile image, and logout functionality. It handles navigation to the login screen and displays a toast message for certain actions.
       - Composable Structure: The ProfileScreen composable displays user profile settings and provides buttons for changing the profile image, editing the username, and logging out. The UI includes state management using the ProfileViewModel.
@@ -225,6 +225,19 @@
       - ClearTokenUseCaseImpl: In the ClearTokenUseCaseImpl implementation, kotlin.runCatching{} was introduced to wrap the token-clearing logic. This guarantees that any exceptions raised during the userDataStore.clear() operation are caught and returned as part of a Result<Unit>.
     - UserDTO Data Model and Domain Conversion
       - UserDTO: A serializable data transfer object (DTO) designed for use with APIs. It represents user-related data fields including id, loginId, userName, extraUserInfo, and profileFilePath.
+    - **Retrofit Integration with Custom Interceptor for Token Management and Dynamic Headers**
+      - GetMyUserUseCaseImpl: Fetching and Mapping User Data
+        - GetMyUserUseCaseImpl: Fetches user data by calling the myPage() API from the UserService. The result is wrapped in a Result<User> to handle potential errors.
+        - Domain Conversion: Converts the response from the DTO format to a domain-specific User model using the toDomainModel() function for further use within the application.
+      - UserDTO Update: Domain Model Conversion Function
+        - Domain Model Conversion Added: The toDomainModel function was added to the UserDTO class, allowing it to be easily converted into a domain-specific User model.
+      - Adding Binding for GetMyUserUseCase in User Module
+        - Binding GetMyUserUseCase Implementation: The bindGetMyUserUseCase function was added to the User module using Dagger's @Binds annotation.
+      - Retrofit and Custom Interceptor Implementation for Token Management and HTTP 401 Error Handling
+        - CustomInterceptor for Dynamic Headers: The CustomInterceptor class was implemented to dynamically inject headers into all API requests. It retrieves the authentication token from UserDataStore and adds it as a "Token" header if available.
+        - OkHttpClient with CustomInterceptor: The OkHttpClient is configured to use CustomInterceptor for injecting headers dynamically. This ensures that headers like the token and content type are automatically included in every request without needing to specify them individually in UserService.
+        - Retrofit Configuration: A Retrofit instance is provided with the OkHttpClient (configured with the interceptor) and a JSON converter that ignores unknown keys.
+        - UserService API Integration: With the interceptor handling the dynamic headers, the UserService interface now relies on Retrofit.create() for API calls, without needing manual @Headers declarations in the service methods.
 
 
 **Task 4: Post Creation**

--- a/data/src/main/java/com/ld5ehom/data/di/RetrofitModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/RetrofitModule.kt
@@ -1,6 +1,7 @@
 package com.ld5ehom.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import com.ld5ehom.data.retrofit.CustomInterceptor
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -21,7 +22,7 @@ class RetrofitModule {
     // Provides and binds the OkHttpClient instance to the Dagger dependency graph
     // (OkHttpClient 인스턴스를 Dagger 의존성 그래프에 제공하고 바인딩함)
     @Provides
-    fun provideOkHttpClient(): OkHttpClient {
+    fun provideOkHttpClient(interceptor: CustomInterceptor): OkHttpClient {
         return OkHttpClient
             .Builder()
             .build()

--- a/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
@@ -9,11 +9,13 @@ import com.ld5ehom.data.usecase.GetTokenUseCaseImpl
 import com.ld5ehom.data.usecase.LoginUseCaseImpl
 import com.ld5ehom.data.usecase.SetTokenUseCaseImpl
 import com.ld5ehom.data.usecase.SignUpUseCaseImpl
+import com.ld5ehom.data.usecase.main.profile.GetMyUserUseCaseImpl
 import com.ld5ehom.domain.usecase.login.ClearTokenUseCase
 import com.ld5ehom.domain.usecase.login.GetTokenUseCase
 import com.ld5ehom.domain.usecase.login.LoginUseCase
 import com.ld5ehom.domain.usecase.login.SignUpUseCase
 import com.ld5ehom.domain.usecase.login.SetTokenUseCase
+import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
 
 
 @Module
@@ -46,4 +48,8 @@ abstract class UserModule {
     // (ClearTokenUseCase 인터페이스에 ClearTokenUseCaseImpl 구현체를 바인딩)
     abstract fun bindClearTokenUseCase(uc: ClearTokenUseCaseImpl): ClearTokenUseCase
 
+    @Binds
+    // Binds the GetMyUserUseCaseImpl to GetMyUserUseCase in the Dagger dependency graph.
+    // (Dagger 의존성 그래프에서 GetMyUserUseCaseImpl을 GetMyUserUseCase에 바인딩함)
+    abstract fun bindGetMyUserUseCase(uc: GetMyUserUseCaseImpl):GetMyUserUseCase
 }

--- a/data/src/main/java/com/ld5ehom/data/model/UserDTO.kt
+++ b/data/src/main/java/com/ld5ehom/data/model/UserDTO.kt
@@ -1,5 +1,6 @@
 package com.ld5ehom.data.model
 
+import com.ld5ehom.domain.model.User
 import kotlinx.serialization.Serializable
 
 @Serializable
@@ -11,3 +12,15 @@ data class UserDTO(
     val extraUserInfo: String,
     val profileFilePath: String,
 )
+
+// Converts UserDTO to a domain-specific User model used for internal business logic.
+// (UserDTO를 도메인 내에서 사용하는 User 모델로 변환하는 함수)
+fun UserDTO.toDomainModel(): User {
+    return User(
+        // Maps the UserDTO fields to User fields. (UserDTO 필드를 User 모델 필드로 매핑)
+        id = this.id,
+        loginId = this.loginId,
+        username = this.userName,
+        profileImageUrl = this.profileFilePath
+    )
+}

--- a/data/src/main/java/com/ld5ehom/data/retrofit/CustomInterceptor.kt
+++ b/data/src/main/java/com/ld5ehom/data/retrofit/CustomInterceptor.kt
@@ -1,0 +1,40 @@
+package com.ld5ehom.data.retrofit
+
+import kotlinx.coroutines.runBlocking
+import com.ld5ehom.data.UserDataStore
+import okhttp3.Interceptor
+import okhttp3.Response
+import javax.inject.Inject
+
+// Intercepts HTTP requests to dynamically add headers such as token and content type.
+// (HTTP 요청을 가로채서 토큰 및 컨텐츠 타입과 같은 헤더를 동적으로 추가함)
+class CustomInterceptor @Inject constructor(
+    // Injected UserDataStore to retrieve the user's token. (사용자의 토큰을 가져오기 위한 UserDataStore 주입)
+    private val userDataStore: UserDataStore
+) : Interceptor {
+
+    // Intercepts the chain of HTTP requests to add headers. (HTTP 요청 체인을 가로채서 헤더를 추가)
+    override fun intercept(chain: Interceptor.Chain): Response {
+        // Fetches the token using runBlocking to ensure it's retrieved before the request proceeds.
+        // (요청이 진행되기 전에 토큰을 가져오기 위해 runBlocking 사용)
+        val token: String? = runBlocking { userDataStore.getToken() }
+
+        // Proceeds with the request, adding the token and content type headers.
+        // (요청을 진행하면서 토큰 및 컨텐츠 타입 헤더 추가)
+        return chain.proceed(
+            chain.request()
+                .newBuilder()
+                .run {
+                    // Adds the token to the header if it is not null or empty. (토큰이 null 또는 비어있지 않으면 헤더에 추가)
+                    if (token.isNullOrEmpty()) {
+                        this
+                    } else {
+                        this.addHeader("Token", token)
+                    }
+                }
+                // Adds the Content-Type header for all requests.(모든 요청에 대해 Content-Type 헤더 추가)
+                .addHeader("Content-Type", "application/json; charset=UTF8")
+                .build()
+        )
+    }
+}

--- a/data/src/main/java/com/ld5ehom/data/usecase/main/profile/GetMyUserUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/main/profile/GetMyUserUseCaseImpl.kt
@@ -1,0 +1,23 @@
+package com.ld5ehom.data.usecase.main.profile
+
+import com.ld5ehom.data.model.toDomainModel
+import com.ld5ehom.data.retrofit.UserService
+import com.ld5ehom.domain.model.User
+import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
+import javax.inject.Inject
+
+// GetMyUserUseCaseImpl retrieves user data by calling the UserService API and mapping it to the domain model
+// (GetMyUserUseCaseImpl는 UserService API를 호출하여 사용자 데이터를 가져오고 이를 도메인 모델로 매핑함)
+class GetMyUserUseCaseImpl @Inject constructor(
+    // Injected UserService to handle network API calls for user data
+    // (사용자 데이터를 가져오기 위한 네트워크 API 호출을 처리하기 위해 UserService 주입)
+    private val userService: UserService
+) : GetMyUserUseCase {
+    // Implements the invoke method to fetch user data from the API and return it as a Result
+    // (API에서 사용자 데이터를 가져오고 이를 Result로 반환하는 invoke 메서드 구현)
+    override suspend fun invoke(): Result<User> = kotlin.runCatching {
+        // Calls the myPage() API, gets the response, and converts the DTO to the User domain model
+        // (myPage() API를 호출하고 응답 데이터를 가져온 후 DTO를 User 도메인 모델로 변환)
+        userService.myPage().data.toDomainModel()
+    }
+}


### PR DESCRIPTION
- GetMyUserUseCaseImpl: Fetching and Mapping User Data
    - GetMyUserUseCaseImpl: Fetches user data by calling the myPage() API from the UserService. The result is wrapped in a Result<User> to handle potential errors.
     - Domain Conversion: Converts the response from the DTO format to a domain-specific User model using the toDomainModel() function for further use within the application. 
- UserDTO Update: Domain Model Conversion Function 
    - Domain Model Conversion Added: The toDomainModel function was added to the UserDTO class, allowing it to be easily converted into a domain-specific User model. 
- Adding Binding for GetMyUserUseCase in User Module 
    - Binding GetMyUserUseCase Implementation: The bindGetMyUserUseCase function was added to the User module using Dagger's @Binds annotation.
- Retrofit and Custom Interceptor Implementation for Token Management and HTTP 401 Error Handling 
    - CustomInterceptor for Dynamic Headers: The CustomInterceptor class was implemented to dynamically inject headers into all API requests. It retrieves the authentication token from UserDataStore and adds it as a Token header if available. 
    - OkHttpClient with CustomInterceptor: The OkHttpClient is configured to use CustomInterceptor for injecting headers dynamically. This ensures that headers like the token and content type are automatically included in every request without needing to specify them individually in UserService. 
    - Retrofit Configuration: A Retrofit instance is provided with the OkHttpClient (configured with the interceptor) and a JSON converter that ignores unknown keys. 
    - UserService API Integration: With the interceptor handling the dynamic headers, the UserService interface now relies on Retrofit.create() for API calls, without needing manual @Headers declarations in the service methods.