### PR TITLE
Profile User Name Change Feature Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,8 +136,6 @@
     - LoginUseCaseImpl Implementation with Dagger for API Integration
       - LoginUseCaseImpl leverages Dagger's @Inject for dependency injection, automatically providing UserService to handle login API calls. The invoke function converts user credentials into a request body, calls the login API, and safely handles the response using Kotlin’s runCatching.
 
-
-
 ### Task 2. Sign Up Page
 - **Issues** : [task-2-signup](https://github.com/ld5ehom/sns-android/tree/task-2-signup)
 - **Details** :
@@ -194,7 +192,7 @@
       - The AppModule class provides the Application context by binding the Application instance to the Context interface. 
       - This setup allows Dagger Hilt to inject the application context wherever the Context type is required within the application.
 
-### Task 3. User Profile Page Setting
+### Task 3. User Profile Page
 - **Issues** : [task-3-profile](https://github.com/ld5ehom/sns-android/tree/task-3-profile)
 - **Details** :
   - **Main Navigation and Route Updates: Enhanced Structure and Navigation Flow** - [60ee919](https://github.com/ld5ehom/sns-android/commit/60ee9199d7caf4b509ada6a5e81f738262e566e4)
@@ -238,24 +236,45 @@
       - OkHttpClient with CustomInterceptor: The OkHttpClient is configured to use CustomInterceptor for injecting headers dynamically. This ensures that headers like the token and content type are automatically included in every request without needing to specify them individually in UserService.
       - Retrofit Configuration: A Retrofit instance is provided with the OkHttpClient (configured with the interceptor) and a JSON converter that ignores unknown keys.
       - UserService API Integration: With the interceptor handling the dynamic headers, the UserService interface now relies on Retrofit.create() for API calls, without needing manual @Headers declarations in the service methods.
-  - **OkHttpClient Interceptor Integration**
+  - **OkHttpClient Interceptor Integration** - [ebed6fa](https://github.com/ld5ehom/sns-android/commit/ebed6fad4d2d3f384eb9f8ad167d5cfebfd594bd)
     - Added CustomInterceptor to OkHttpClient using .addInterceptor() to dynamically inject headers, such as tokens, into every API request for handling authentication and preventing HTTP 401 errors.
+  - **Profile User Name Change Feature Update**
+    - presentation/profile/UsernameDialog
+      - The UsernameDialog composable provides a dialog interface for users to update their profile name. It displays an input field pre-filled with the user's current username, and allows the user to modify it. This functionality is designed for efficient and interactive profile name management, with callbacks for handling changes and dismissing the dialog.
+    - ProfileScreen Update  
+      - The ProfileScreen was updated to allow users to change their username by displaying a UsernameDialog. The dialog collects the new username and triggers an API call to update the user's profile.
+      - The dialog is shown when usernameDialogVisible is true, and the new username is passed to the onUsernameChange function in ProfileViewModel, which handles the update logic.
+    - ProfileViewModel update: 
+      - Username Change Handling: A new method onUsernameChange is added to the Profile ViewModel, which calls the setMyUserUseCase to update the user's profile name with the provided username.
+      - State Management: The use case is executed within an intent block, and if successful, the updated profile is reloaded by calling load(), ensuring the UI reflects the changes immediately.
+    - UserService Update 
+      - A new patchMyPage method was added to the UserService interface. This method sends a PATCH request to update the user's profile by accepting a RequestBody as input and returning a CommonResponse<Long>.
+    - SetMyUserUseCaseImpl: Handling User Profile Updates
+      - User Profile Update: The SetMyUserUseCaseImpl implementation handles updating the user's profile by sending the updated username and profile image URL to the server via UserService.
+      - Fetch and Merge Current Data: If the new username or profile image is not provided, it fetches the current user data using GetMyUserUseCase to ensure no data is lost during the update.
+      - API Integration: It uses UserService.patchMyPage to send the update request to the server after constructing the request body with UpdateMyInfoParam.
+    - UpdateMyInfoParam: Data Class for User Profile Updates
+      - User Profile Update: UpdateMyInfoParam is a serializable data class used to encapsulate the parameters needed for updating user information (username, profile image path, and extra user details) via API.
+      - JSON Serialization: It includes a toRequestBody method that converts the data into a JSON-formatted RequestBody, which is essential for making API requests.
+      - API Communication: The data is serialized to ensure it's in the correct format for being transmitted to the backend through the patchMyPage API.
+    - UserModule : Binding SetMyUserUseCase Implementation in UserModule
+      - Dependency Injection with Dagger: This line of code in the UserModule binds the SetMyUserUseCaseImpl implementation to the SetMyUserUseCase interface using Dagger's @Binds annotation.
 
 
 
-**Task 4: Post Creation**
-- **Issues** :
+### Task 4: Post Creation
+- **Issues** : 
 - Develop functionality for users to create and submit new posts.
 
-**Task 5: Post List Screen**
+### Task 5: Post List Screen**
 - **Issues** :
 - Build a screen that displays a list of posts in a feed or timeline format.
 
-**Task 6: Comments**
+### Task 6: Comments**
 - **Issues** :
 - Implement a feature that allows users to view and add comments on posts.
 
-**Task 7: Advanced Features and Testing**
+### Task 7: Advanced Features and Testing**
 - **Issues** :
 
 -----

--- a/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
@@ -10,12 +10,14 @@ import com.ld5ehom.data.usecase.LoginUseCaseImpl
 import com.ld5ehom.data.usecase.SetTokenUseCaseImpl
 import com.ld5ehom.data.usecase.SignUpUseCaseImpl
 import com.ld5ehom.data.usecase.main.profile.GetMyUserUseCaseImpl
+import com.ld5ehom.data.usecase.main.profile.SetMyUserUseCaseImpl
 import com.ld5ehom.domain.usecase.login.ClearTokenUseCase
 import com.ld5ehom.domain.usecase.login.GetTokenUseCase
 import com.ld5ehom.domain.usecase.login.LoginUseCase
 import com.ld5ehom.domain.usecase.login.SignUpUseCase
 import com.ld5ehom.domain.usecase.login.SetTokenUseCase
 import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
+import com.ld5ehom.domain.usecase.main.profile.SetMyUserUseCase
 
 
 @Module
@@ -52,4 +54,10 @@ abstract class UserModule {
     // Binds the GetMyUserUseCaseImpl to GetMyUserUseCase in the Dagger dependency graph.
     // (Dagger 의존성 그래프에서 GetMyUserUseCaseImpl을 GetMyUserUseCase에 바인딩함)
     abstract fun bindGetMyUserUseCase(uc: GetMyUserUseCaseImpl):GetMyUserUseCase
+
+    @Binds
+    // Binds the SetMyUserUseCaseImpl implementation to the SetMyUserUseCase interface
+    // (SetMyUserUseCase 인터페이스에 SetMyUserUseCaseImpl 구현체를 바인딩함)
+    abstract fun bindUpdateMyNameUseCase(uc: SetMyUserUseCaseImpl): SetMyUserUseCase
+
 }

--- a/data/src/main/java/com/ld5ehom/data/model/UpdateMyInfoParam.kt
+++ b/data/src/main/java/com/ld5ehom/data/model/UpdateMyInfoParam.kt
@@ -1,0 +1,22 @@
+package com.ld5ehom.data.model
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
+
+// Data class to hold parameters for updating user information via the API
+// (API를 통해 사용자 정보를 업데이트하기 위한 파라미터를 보유한 데이터 클래스)
+@Serializable
+data class UpdateMyInfoParam(
+    val userName: String,
+    val extraUserInfo: String,
+    val profileFilePath: String, // Path to the user's profile image
+) {
+    // Converts the data class to a JSON request body for API communication
+    // (API 통신을 위한 JSON 요청 본문으로 변환)
+    fun toRequestBody(): RequestBody {
+        return Json.encodeToString(this).toRequestBody() // Converts the object to JSON string and wraps it in a request body
+    }
+}

--- a/data/src/main/java/com/ld5ehom/data/retrofit/UserService.kt
+++ b/data/src/main/java/com/ld5ehom/data/retrofit/UserService.kt
@@ -4,26 +4,28 @@ import com.ld5ehom.data.model.CommonResponse
 import com.ld5ehom.data.model.UserDTO
 import okhttp3.RequestBody
 import retrofit2.http.Body
-import retrofit2.http.Headers
 import retrofit2.http.GET
+import retrofit2.http.PATCH
 import retrofit2.http.POST
 
 interface UserService {
 
     @POST("users/login")
-    @Headers("Content-Type:application/json; charset=UTF8") // for HTTP 500 error
     suspend fun login(
         @Body requestBody: RequestBody  // parameter
     ):CommonResponse<String>
 
     @POST("users/sign-up")
-    @Headers("Content-Type:application/json; charset=UTF8")
     suspend fun signUp(
         @Body requestBody: RequestBody
     ):CommonResponse<Long>
 
     @GET("users/my-page")
-    @Headers("Content-Type:application/json; charset=UTF8")
-    suspend fun myPage():CommonResponse<UserDTO>
+    suspend fun getMyPage():CommonResponse<UserDTO>
+
+    @PATCH("users/my-page")
+    suspend fun patchMyPage(
+        @Body requestBody:RequestBody
+    ):CommonResponse<Long>
 
 }

--- a/data/src/main/java/com/ld5ehom/data/usecase/main/profile/GetMyUserUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/main/profile/GetMyUserUseCaseImpl.kt
@@ -18,6 +18,6 @@ class GetMyUserUseCaseImpl @Inject constructor(
     override suspend fun invoke(): Result<User> = kotlin.runCatching {
         // Calls the myPage() API, gets the response, and converts the DTO to the User domain model
         // (myPage() API를 호출하고 응답 데이터를 가져온 후 DTO를 User 도메인 모델로 변환)
-        userService.myPage().data.toDomainModel()
+        userService.getMyPage().data.toDomainModel()
     }
 }

--- a/data/src/main/java/com/ld5ehom/data/usecase/main/profile/SetMyUserUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/main/profile/SetMyUserUseCaseImpl.kt
@@ -1,0 +1,35 @@
+package com.ld5ehom.data.usecase.main.profile
+
+import com.ld5ehom.data.model.UpdateMyInfoParam
+import com.ld5ehom.data.retrofit.UserService
+import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
+import com.ld5ehom.domain.usecase.main.profile.SetMyUserUseCase
+import javax.inject.Inject
+
+// Implements SetMyUserUseCase to handle user profile updates
+// (SetMyUserUseCase를 구현하여 사용자 프로필 업데이트 처리)
+class SetMyUserUseCaseImpl @Inject constructor(
+    // Injected UserService for API interactions and GetMyUserUseCase to fetch current user data
+    // (API 상호작용을 위한 UserService와 현재 사용자 데이터를 가져오는 GetMyUserUseCase 주입)
+    private val userService: UserService,
+    private val getMyUserUseCase: GetMyUserUseCase
+) : SetMyUserUseCase {
+
+    // Updates the user profile with the provided username and profile image URL
+    // (제공된 사용자 이름과 프로필 이미지 URL로 사용자 프로필을 업데이트)
+    override suspend fun invoke(
+        username: String?, // New username
+        profileImageUrl: String? // New profile image URL
+    ): Result<Unit> = kotlin.runCatching {
+        val user = getMyUserUseCase().getOrThrow()  // Fetches the current user data
+
+        // Creates request body with the updated user data
+        val requestBody = UpdateMyInfoParam(
+            userName = username ?: user.username, // Uses existing username if new one is null (새 이름이 null일 경우 기존 이름 사용)
+            profileFilePath = user.profileImageUrl.orEmpty(), // Uses existing image URL if new one is null (새 이미지가 null일 경우 기존 이미지 사용)
+            extraUserInfo = "" // Additional info placeholder
+        ).toRequestBody()
+
+        userService.patchMyPage(requestBody) // Calls the API to update the user's profile
+    }
+}

--- a/domain/src/main/java/com/ld5ehom/domain/usecase/main/profile/SetMyUserUseCase.kt
+++ b/domain/src/main/java/com/ld5ehom/domain/usecase/main/profile/SetMyUserUseCase.kt
@@ -1,0 +1,8 @@
+package com.ld5ehom.domain.usecase.main.profile
+
+interface SetMyUserUseCase {
+    suspend operator fun invoke(
+        username: String? = null,
+        profileImageUrl:String? = null
+    ): Result<Unit>
+}

--- a/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileScreen.kt
@@ -2,6 +2,9 @@ package com.ld5ehom.presentation.main.profile
 
 import android.content.Intent
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -21,6 +24,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -40,6 +47,9 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun ProfileScreen(viewModel: ProfileViewModel = hiltViewModel()) {
     val context = LocalContext.current
     val state = viewModel.collectAsState().value
+    var usernameDialogVisible by remember {
+        mutableStateOf(false)
+    }
 
     // Handles side effects such as showing a toast message or navigating to the login screen
     // (토스트 메시지 표시나 로그인 화면으로의 네비게이션 같은 부수 효과를 처리)
@@ -67,8 +77,17 @@ fun ProfileScreen(viewModel: ProfileViewModel = hiltViewModel()) {
         username = state.username,
         profileImageUrl = state.profileImageUrl,
         onImageChangeClick = {},
-        onNameChangeClick = {},
+        onNameChangeClick = { usernameDialogVisible = true },
         onLogoutClick = viewModel::onLogoutClick
+    )
+
+    // Shows UsernameDialog for changing username and handles changes
+    // (사용자 이름을 변경하기 위한 UsernameDialog를 표시하고 변경을 처리)
+    UsernameDialog(
+        visible = usernameDialogVisible,
+        initialUsername = state.username,
+        onUsernameChange = viewModel::onUsernameChange,
+        onDismissRequest = { usernameDialogVisible = false }
     )
 }
 

--- a/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileViewModel.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import com.ld5ehom.domain.model.User
 import com.ld5ehom.domain.usecase.login.ClearTokenUseCase
 import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
+import com.ld5ehom.domain.usecase.main.profile.SetMyUserUseCase
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -25,7 +26,11 @@ class ProfileViewModel @Inject constructor(
 
     // Injected GetMyUserUseCase to retrieve the current user's profile information
     // (현재 사용자의 프로필 정보를 가져오기 위한 GetMyUserUseCase 주입)
-    private val getMyUserUseCase: GetMyUserUseCase
+    private val getMyUserUseCase: GetMyUserUseCase,
+
+    // Injected SetMyUserUseCase to update the current user's profile information
+    // (현재 사용자의 프로필 정보를 업데이트하기 위한 SetMyUserUseCase 주입)
+    private val setMyUserUseCase: SetMyUserUseCase,
 ) : ViewModel(), ContainerHost<ProfileState, ProfileSideEffect> {
 
     // Container for managing state and side effects in Orbit MVI
@@ -70,6 +75,14 @@ class ProfileViewModel @Inject constructor(
         clearTokenUseCase().getOrThrow()  // Clears the user token
         postSideEffect(ProfileSideEffect.NavigateToLoginActivity)  // Triggers navigation to the login screen
     }
+
+    // Handles the username change by calling setMyUserUseCase to update the user's profile
+    // (사용자의 프로필을 업데이트하기 위해 setMyUserUseCase를 호출하여 사용자 이름을 변경 처리함)
+    fun onUsernameChange(username: String) = intent {
+        setMyUserUseCase(username = username).getOrThrow()   // Executes the use case to update the username and throws an exception if it fails
+        load()
+    }
+
 }
 
 // Immutable state class to hold profile data

--- a/presentation/src/main/java/com/ld5ehom/presentation/main/profile/UsernameDialog.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/main/profile/UsernameDialog.kt
@@ -1,0 +1,87 @@
+package com.ld5ehom.presentation.main.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.window.Dialog
+import com.ld5ehom.presentation.theme.SNSTheme
+
+@OptIn(ExperimentalMaterial3Api::class)
+// Composable function for showing a username update dialog
+// (사용자 이름 변경 다이얼로그를 표시하는 컴포저블 함수)
+@Composable
+fun UsernameDialog(
+    visible: Boolean = false,
+    initialUsername: String,  // Initial username to display
+    onUsernameChange: (String) -> Unit,  // Callback for when the username is changed (사용자 이름이 변경되었을 때 호출되는 콜백 함수)
+    onDismissRequest: () -> Unit  // Callback for dismissing the dialog
+) {
+    if (visible) {
+        var username by remember {
+            mutableStateOf(initialUsername) // State for the current username
+        }
+
+        Dialog(onDismissRequest = onDismissRequest) {
+            Surface {
+                Column(modifier = Modifier.fillMaxWidth(0.8f)) {
+                    TextField(
+                        modifier = Modifier.fillMaxWidth(),  // Full-width text field for username input
+                        value = username,
+                        textStyle = LocalTextStyle.current.copy(
+                            textAlign = TextAlign.Center,
+                            color = Color.Black
+                        ),
+                        onValueChange = {
+                            username = it  // Updates the username state on text change (텍스트가 변경될 때 사용자 이름 상태를 업데이트)
+                        }
+                    )
+                    Row {
+                        TextButton(
+                            modifier = Modifier.weight(1f),
+                            onClick = {
+                                onUsernameChange(username)  // Triggers the username change callback (사용자 이름 변경 콜백 호출)
+                                onDismissRequest()  // Closes the dialog
+                            }
+                        ) {
+                            Text(text = "Change")
+                        }
+                        TextButton(
+                            modifier = Modifier.weight(1f),
+                            onClick = onDismissRequest  // Closes the dialog
+                        ) {
+                            Text(text = "Cancel")
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview
+@Composable
+private fun UsernameDialogPreview() {
+    SNSTheme {
+        UsernameDialog(
+            visible = true,
+            initialUsername = "Taewook",
+            onUsernameChange = {},
+            onDismissRequest = {}
+        )
+    }
+}


### PR DESCRIPTION
- presentation/profile/UsernameDialog 
    - The UsernameDialog composable provides a dialog interface for users to update their profile name. It displays an input field pre-filled with the user's current username, and allows the user to modify it. This functionality is designed for efficient and interactive profile name management, with callbacks for handling changes and dismissing the dialog.
- ProfileScreen Update
    - The ProfileScreen was updated to allow users to change their username by displaying a UsernameDialog. The dialog collects the new username and triggers an API call to update the user's profile.
    - The dialog is shown when usernameDialogVisible is true, and the new username is passed to the onUsernameChange function in ProfileViewModel, which handles the update logic.
- ProfileViewModel update: 
    - Username Change Handling: A new method onUsernameChange is added to the Profile ViewModel, which calls the setMyUserUseCase to update the user's profile name with the provided username. 
    - State Management: The use case is executed within an intent block, and if successful, the updated profile is reloaded by calling load(), ensuring the UI reflects the changes immediately.
- UserService Update
    - A new patchMyPage method was added to the UserService interface. This method sends a PATCH request to update the user's profile by accepting a RequestBody as input and returning a CommonResponse<Long>.
- SetMyUserUseCaseImpl: Handling User Profile Updates 
    - User Profile Update: The SetMyUserUseCaseImpl implementation handles updating the user's profile by sending the updated username and profile image URL to the server via UserService. 
    - Fetch and Merge Current Data: If the new username or profile image is not provided, it fetches the current user data using GetMyUserUseCase to ensure no data is lost during the update. 
    - API Integration: It uses UserService.patchMyPage to send the update request to the server after constructing the request body with UpdateMyInfoParam.
- UpdateMyInfoParam: Data Class for User Profile Updates
    - User Profile Update: UpdateMyInfoParam is a serializable data class used to encapsulate the parameters needed for updating user information (username, profile image path, and extra user details) via API.
    - JSON Serialization: It includes a toRequestBody method that converts the data into a JSON-formatted RequestBody, which is essential for making API requests. - API Communication: The data is serialized to ensure it's in the correct format for being transmitted to the backend through the patchMyPage API.
- UserModule : Binding SetMyUserUseCase Implementation in UserModule 
    - Dependency Injection with Dagger: This line of code in the UserModule binds the SetMyUserUseCaseImpl implementation to the SetMyUserUseCase interface using Dagger's @Binds annotation.