### PR TITLE
Profile User Image Change Feature Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@
       - UserService API Integration: With the interceptor handling the dynamic headers, the UserService interface now relies on Retrofit.create() for API calls, without needing manual @Headers declarations in the service methods.
   - **OkHttpClient Interceptor Integration** - [ebed6fa](https://github.com/ld5ehom/sns-android/commit/ebed6fad4d2d3f384eb9f8ad167d5cfebfd594bd)
     - Added CustomInterceptor to OkHttpClient using .addInterceptor() to dynamically inject headers, such as tokens, into every API request for handling authentication and preventing HTTP 401 errors.
-  - **Profile User Name Change Feature Update**
+  - **Profile User Name Change Feature Update** - [1953696](https://github.com/ld5ehom/sns-android/commit/19536963c4a2385016e4af3d3373cb47e8e5fa80)
     - presentation/profile/UsernameDialog
       - The UsernameDialog composable provides a dialog interface for users to update their profile name. It displays an input field pre-filled with the user's current username, and allows the user to modify it. This functionality is designed for efficient and interactive profile name management, with callbacks for handling changes and dismissing the dialog.
     - ProfileScreen Update  
@@ -259,6 +259,34 @@
       - API Communication: The data is serialized to ensure it's in the correct format for being transmitted to the backend through the patchMyPage API.
     - UserModule : Binding SetMyUserUseCase Implementation in UserModule
       - Dependency Injection with Dagger: This line of code in the UserModule binds the SetMyUserUseCaseImpl implementation to the SetMyUserUseCase interface using Dagger's @Binds annotation.
+  - **Profile User Image Change Feature Update**
+    - ProfileScreen Update : Image Change Feature Added
+      - Integrated an image picker using rememberLauncherForActivityResult to allow users to select an image from their device. When the user clicks to change the profile image, the media picker is launched, limited to image files only. The selected image is then handled in the ViewModel's onImageChange function to update the profile picture.
+    - ProfileViewModel Update : Profile Image Update Handling
+      - The onImageChange function updates the user's profile image by calling setProfileImageUseCase and reloading the user's profile to reflect the changes.
+    - SetProfileImageUseCase: Interface Definition and Domain Considerations
+      - SetProfileImageUseCase defines a contract for updating the user's profile image using a content URI.
+      - Since the Android Uri class is part of the Android framework and cannot be used in the domain layer, the content URI is passed as a String to maintain platform independence.
+    - SetProfileImageUseCaseImpl: Image Upload Logic 
+      - The image upload flow involves fetching user information, retrieving image details from the URI, uploading the image to the server, and updating the profile with the new image URL.
+    - Image Data Model : Serialization Dependency
+      - In Android's Clean Architecture, data resides at the core of the application, and the architecture's dependency rule allows the outer layers (such as data or presentation) to depend on the inner core (domain). Hence, the Image class is placed in the domain layer, and rather than creating separate DTOs or UI models for the data and presentation layers, the same model is reused across the entire app to simplify code structure.
+      - Kotlinx.serialization.json was added as a dependency to handle the serialization and deserialization of the Image data model into and from JSON. This enables seamless conversion of the Image data class for network communication and data persistence.
+    - UploadImageUseCaseImpl: Uploading Images via FileService 
+      - The UploadImageUseCaseImpl class is responsible for uploading images to the server using FileService. It converts the image into multipart form data, including the file name and image file itself, and returns the file path of the uploaded image.
+    - FileService : File Upload API
+      - This API defines an interface for uploading files using multipart form data, including the file name and the file itself.
+    - data/di/RetofitModule Update : FileService Binding
+      - This update adds functionality for binding the FileService interface to Retrofit, enabling API calls for file uploads.
+    - UriRequestBody : Handling Content Upload from URI
+      - UriRequestBody is a custom RequestBody class used for uploading files from a content URI. It retrieves the input stream from the URI and writes it to a BufferedSink, handling multipart file uploads.
+    - GetInputStreamUseCaseImpl: Fetching InputStream from Content URI
+      - The GetInputStreamUseCaseImpl class implements the logic to retrieve an InputStream from a content URI using the Android content resolver. It returns the result wrapped in a Result object.
+    - FileModule: Binding Use Cases to Interfaces
+      - This module binds the implementations of GetInputStreamUseCase, GetImageUseCase, and UploadImageUseCase to their respective interfaces. These bindings are installed in a SingletonComponent.
+    - GetImageUseCaseImpl: Retrieving Image Metadata from URI
+      - The GetImageUseCaseImpl class is responsible for retrieving metadata, such as the image name, size, and MIME type, from a content URI using the content resolver. It returns an Image object with the gathered information.
+
 
 
 
@@ -266,15 +294,15 @@
 - **Issues** : 
 - Develop functionality for users to create and submit new posts.
 
-### Task 5: Post List Screen**
+### Task 5: Post List Screen
 - **Issues** :
 - Build a screen that displays a list of posts in a feed or timeline format.
 
-### Task 6: Comments**
+### Task 6: Comments
 - **Issues** :
 - Implement a feature that allows users to view and add comments on posts.
 
-### Task 7: Advanced Features and Testing**
+### Task 7: Advanced Features and Testing
 - **Issues** :
 
 -----

--- a/data/src/main/java/com/ld5ehom/data/di/FileModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/FileModule.kt
@@ -1,0 +1,28 @@
+package com.ld5ehom.data.di
+
+import dagger.Binds
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import com.ld5ehom.data.usecase.file.GetImageUseCaseImpl
+import com.ld5ehom.data.usecase.file.GetInputStreamUseCaseImpl
+import com.ld5ehom.data.usecase.file.UploadImageUseCaseImpl
+import com.ld5ehom.domain.usecase.file.GetImageUseCase
+import com.ld5ehom.domain.usecase.file.GetInputStreamUseCase
+import com.ld5ehom.domain.usecase.file.UploadImageUseCase
+
+@Module
+@InstallIn(SingletonComponent::class)
+// This module binds implementations of use cases to their respective interfaces within a SingletonComponent.
+// 이 모듈은 SingletonComponent 내에서 유즈케이스 구현체들을 해당 인터페이스에 바인딩합니다.
+abstract class FileModule {
+
+    @Binds
+    abstract fun bindGetInputStreamUseCase(uc: GetInputStreamUseCaseImpl): GetInputStreamUseCase
+
+    @Binds
+    abstract fun bindGetImageUseCase(uc: GetImageUseCaseImpl): GetImageUseCase
+
+    @Binds
+    abstract fun bindUploadImageUseCase(uc: UploadImageUseCaseImpl): UploadImageUseCase
+}

--- a/data/src/main/java/com/ld5ehom/data/di/RetrofitModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/RetrofitModule.kt
@@ -2,6 +2,7 @@ package com.ld5ehom.data.di
 
 import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
 import com.ld5ehom.data.retrofit.CustomInterceptor
+import com.ld5ehom.data.retrofit.FileService
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -49,4 +50,12 @@ class RetrofitModule {
     fun provideUserService(retrofit: Retrofit): UserService {  // Creates and binds UserService using Retrofit for API requests
         return retrofit.create(UserService::class.java)
     }
+
+
+     // Binds the FileService to Retrofit for API calls. (파일 서비스를 Retrofit에 바인딩하여 API 호출 가능하게 함.)
+    @Provides
+    fun provideFileService(retrofit: Retrofit): FileService {
+        return retrofit.create(FileService::class.java)
+    }
+
 }

--- a/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
+++ b/data/src/main/java/com/ld5ehom/data/di/UserModule.kt
@@ -11,6 +11,7 @@ import com.ld5ehom.data.usecase.SetTokenUseCaseImpl
 import com.ld5ehom.data.usecase.SignUpUseCaseImpl
 import com.ld5ehom.data.usecase.main.profile.GetMyUserUseCaseImpl
 import com.ld5ehom.data.usecase.main.profile.SetMyUserUseCaseImpl
+import com.ld5ehom.data.usecase.main.profile.SetProfileImageUseCaseImpl
 import com.ld5ehom.domain.usecase.login.ClearTokenUseCase
 import com.ld5ehom.domain.usecase.login.GetTokenUseCase
 import com.ld5ehom.domain.usecase.login.LoginUseCase
@@ -18,6 +19,7 @@ import com.ld5ehom.domain.usecase.login.SignUpUseCase
 import com.ld5ehom.domain.usecase.login.SetTokenUseCase
 import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
 import com.ld5ehom.domain.usecase.main.profile.SetMyUserUseCase
+import com.ld5ehom.domain.usecase.main.profile.SetProfileImageUseCase
 
 
 @Module
@@ -27,37 +29,26 @@ import com.ld5ehom.domain.usecase.main.profile.SetMyUserUseCase
 abstract class UserModule {
 
     @Binds
-    // Binds LoginUseCaseImpl to the LoginUseCase interface
-    // (LoginUseCaseImpl을 LoginUseCase 인터페이스에 바인딩)
     abstract fun bindLoginUseCase(uc: LoginUseCaseImpl): LoginUseCase
 
     @Binds
-    // Binds SignUpUseCaseImpl to the SignUpUseCase interface
     abstract fun bindSignUpUseCase(uc: SignUpUseCaseImpl):SignUpUseCase
 
     @Binds
-    // Binds GetTokenUseCaseImpl implementation to the GetTokenUseCase interface
-    // (GetTokenUseCase 인터페이스에 GetTokenUseCaseImpl 구현체를 바인딩)
     abstract fun bindGetTokenUseCase(uc: GetTokenUseCaseImpl): GetTokenUseCase
 
     @Binds
-    // Binds SetTokenUseCaseImpl implementation to the SetTokenUseCase interface
-    // (SetTokenUseCase 인터페이스에 SetTokenUseCaseImpl 구현체를 바인딩)
     abstract fun bindSetTokenUseCase(uc: SetTokenUseCaseImpl): SetTokenUseCase
 
     @Binds
-    // Binds ClearTokenUseCaseImpl implementation to the ClearTokenUseCase interface
-    // (ClearTokenUseCase 인터페이스에 ClearTokenUseCaseImpl 구현체를 바인딩)
     abstract fun bindClearTokenUseCase(uc: ClearTokenUseCaseImpl): ClearTokenUseCase
 
     @Binds
-    // Binds the GetMyUserUseCaseImpl to GetMyUserUseCase in the Dagger dependency graph.
-    // (Dagger 의존성 그래프에서 GetMyUserUseCaseImpl을 GetMyUserUseCase에 바인딩함)
     abstract fun bindGetMyUserUseCase(uc: GetMyUserUseCaseImpl):GetMyUserUseCase
 
     @Binds
-    // Binds the SetMyUserUseCaseImpl implementation to the SetMyUserUseCase interface
-    // (SetMyUserUseCase 인터페이스에 SetMyUserUseCaseImpl 구현체를 바인딩함)
     abstract fun bindUpdateMyNameUseCase(uc: SetMyUserUseCaseImpl): SetMyUserUseCase
 
+    @Binds
+    abstract fun bindSetProfileImageUseCase(uc: SetProfileImageUseCaseImpl):SetProfileImageUseCase
 }

--- a/data/src/main/java/com/ld5ehom/data/model/FileDTO.kt
+++ b/data/src/main/java/com/ld5ehom/data/model/FileDTO.kt
@@ -1,0 +1,11 @@
+package com.ld5ehom.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class FileDTO(
+    val id:Long,
+    val fileName:String,
+    val createdAt:String,
+    val filePath:String
+)

--- a/data/src/main/java/com/ld5ehom/data/retrofit/FileService.kt
+++ b/data/src/main/java/com/ld5ehom/data/retrofit/FileService.kt
@@ -1,0 +1,34 @@
+package com.ld5ehom.data.retrofit
+
+import com.ld5ehom.data.model.CommonResponse
+import com.ld5ehom.data.model.FileDTO
+import okhttp3.MultipartBody
+import retrofit2.http.Headers
+import retrofit2.http.Multipart
+import retrofit2.http.POST
+import retrofit2.http.Part
+
+/**
+ * - Defines the API for uploading files with multipart form data.
+ * - 멀티파트 폼 데이터를 사용하여 파일을 업로드하는 API 정의.
+ */
+interface FileService {
+
+    /**
+     * Upload File
+     * - Uploads a file using multipart/form-data. (멀티파트/form-data를 사용하여 파일을 업로드.)
+     * - Accepts the file name and the actual file as parts. (파일 이름과 실제 파일을 파트로 전달.)
+     * - Returns a common response containing file details. (파일 세부 정보를 포함하는 공통 응답 반환.)
+     *
+     * @param fileName The name of the file being uploaded, sent as a multipart form-data part. (업로드할 파일의 이름, 멀티파트 폼 데이터로 전송.)
+     * @param file The file being uploaded, sent as a multipart form-data part.(업로드할 파일, 멀티파트 폼 데이터로 전송.)
+     * @return CommonResponse<FileDTO> A response containing the details of the uploaded file. (업로드된 파일 세부 정보를 포함한 응답.)
+     */
+    @POST("files")
+    @Multipart
+    @Headers("ContentType: multipart/form-data;")
+    suspend fun uploadFile(
+        @Part fileName: MultipartBody.Part,
+        @Part file: MultipartBody.Part
+    ): CommonResponse<FileDTO>
+}

--- a/data/src/main/java/com/ld5ehom/data/retrofit/UriRequestBody.kt
+++ b/data/src/main/java/com/ld5ehom/data/retrofit/UriRequestBody.kt
@@ -1,0 +1,45 @@
+package com.ld5ehom.data.retrofit
+
+import android.util.Log
+import com.ld5ehom.domain.usecase.file.GetInputStreamUseCase
+import okhttp3.MediaType
+import okhttp3.RequestBody
+import okio.BufferedSink
+import okio.FileNotFoundException
+import okio.source
+
+// A custom RequestBody class that handles reading a file from a content URI and writing it to a BufferedSink for multipart upload.
+// 파일을 콘텐츠 URI에서 읽고 BufferedSink로 멀티파트 업로드를 처리하는 커스텀 RequestBody 클래스.
+class UriRequestBody constructor(
+    val contentUri: String,  // The URI of the content to be uploaded (업로드할 콘텐츠의 URI)
+    val getInputStreamUseCase: GetInputStreamUseCase,  // Use case for retrieving the input stream from the URI (URI에서 입력 스트림을 가져오는 유즈케이스)
+    val contentType: MediaType? = null,  // The MIME type of the content
+    val contentLength: Long,  // The size of the content
+) : RequestBody() {
+
+    // Returns the MIME type of the content (콘텐츠의 MIME 타입 반환)
+    override fun contentType(): MediaType? {
+        return contentType
+    }
+
+    // Returns the size of the content (콘텐츠의 크기 반환)
+    override fun contentLength(): Long {
+        return contentLength
+    }
+
+    // Writes the content to the provided BufferedSink (제공된 BufferedSink로 콘텐츠를 작성)
+    override fun writeTo(sink: BufferedSink) {
+        try {
+            // Fetch the input stream from the URI and write to the sink (URI에서 입력 스트림을 가져와 sink로 작성)
+            getInputStreamUseCase(
+                contentUri = contentUri
+            )
+                .getOrThrow()
+                .use { inputStream ->
+                    sink.writeAll(inputStream.source())  // Write the entire input stream to the sink (전체 입력 스트림을 sink에 작성)
+                }
+        } catch (e: FileNotFoundException) {
+            Log.e("UriRequestBody", e.message.orEmpty())  // Log any FileNotFoundException (FileNotFoundException 로그 기록)
+        }
+    }
+}

--- a/data/src/main/java/com/ld5ehom/data/usecase/file/GetImageUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/file/GetImageUseCaseImpl.kt
@@ -1,0 +1,51 @@
+package com.ld5ehom.data.usecase.file
+
+import android.content.Context
+import android.net.Uri
+import android.provider.MediaStore
+import com.ld5ehom.domain.model.Image
+import com.ld5ehom.domain.usecase.file.GetImageUseCase
+import javax.inject.Inject
+
+// This class implements the GetImageUseCase interface and retrieves image metadata from a given content URI.
+// 이 클래스는 GetImageUseCase 인터페이스를 구현하며, 주어진 콘텐츠 URI에서 이미지 메타데이터를 가져옵니다.
+class GetImageUseCaseImpl @Inject constructor(
+    private val context: Context  // Application context used to access content resolver (콘텐츠 리졸버에 접근하기 위한 애플리케이션 컨텍스트)
+) : GetImageUseCase {
+
+    // Retrieves image metadata from the given content URI (주어진 콘텐츠 URI에서 이미지 메타데이터를 가져옴)
+    override fun invoke(contentUri: String): Image? {
+        val uri = Uri.parse(contentUri)  // Parse the content URI (콘텐츠 URI를 파싱)
+        val projection = arrayOf(  // Define the columns to query from the media store (미디어 스토어에서 쿼리할 열 정의)
+            MediaStore.Images.Media._ID,
+            MediaStore.Images.Media.DISPLAY_NAME,
+            MediaStore.Images.Media.SIZE,
+            MediaStore.Images.Media.MIME_TYPE,
+        )
+        val cursor = context.contentResolver.query(  // Query the content resolver for the image data (콘텐츠 리졸버에 이미지 데이터 쿼리)
+            uri,
+            projection,
+            null,
+            null,
+            null
+        )
+
+        return cursor?.use { c ->  // Use the cursor to extract image metadata (커서를 사용하여 이미지 메타데이터 추출)
+            c.moveToNext()
+            val idIndex = c.getColumnIndexOrThrow(MediaStore.Images.Media._ID)  // Get the index for the image ID column (이미지 ID 열의 인덱스를 가져옴)
+            val nameIndex = c.getColumnIndexOrThrow(MediaStore.Images.Media.DISPLAY_NAME)  // Get the index for the image name column (이미지 이름 열의 인덱스)
+            val sizeIndex = c.getColumnIndexOrThrow(MediaStore.Images.Media.SIZE)  // Get the index for the image size column (이미지 크기 열의 인덱스)
+            val mimeTypeIndex = c.getColumnIndexOrThrow(MediaStore.Images.Media.MIME_TYPE)  // Get the index for the MIME type column (MIME 타입 열의 인덱스)
+
+            val name = cursor.getString(nameIndex)  // Extract the image name (이미지 이름 추출)
+            val size = cursor.getLong(sizeIndex)  // Extract the image size (이미지 크기 추출)
+            val mimeType = cursor.getString(mimeTypeIndex)  // Extract the MIME type (MIME 타입 추출)
+            Image(
+                uri = contentUri,  // Set the image URI (이미지 URI 설정)
+                name = name,  // Set the image name (이미지 이름 설정)
+                size = size,  // Set the image size (이미지 크기 설정)
+                mimeType = mimeType  // Set the MIME type (MIME 타입 설정)
+            )
+        }
+    }
+}

--- a/data/src/main/java/com/ld5ehom/data/usecase/file/GetInputStreamUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/file/GetInputStreamUseCaseImpl.kt
@@ -1,0 +1,21 @@
+package com.ld5ehom.data.usecase.file
+
+import android.content.Context
+import android.net.Uri
+import com.ld5ehom.domain.usecase.file.GetInputStreamUseCase
+import java.io.InputStream
+import javax.inject.Inject
+
+// This class implements the GetInputStreamUseCase interface and provides a method to open an InputStream from a content URI.
+// 이 클래스는 GetInputStreamUseCase 인터페이스를 구현하며, 콘텐츠 URI에서 InputStream을 여는 메서드를 제공합니다.
+class GetInputStreamUseCaseImpl @Inject constructor(
+    private val context: Context  // Application context used to access content resolver (콘텐츠 리졸버에 접근하기 위한 애플리케이션 컨텍스트)
+) : GetInputStreamUseCase {
+
+    // Fetches the InputStream from the given content URI (주어진 콘텐츠 URI에서 InputStream을 가져옴)
+    override fun invoke(contentUri: String): Result<InputStream> = kotlin.runCatching {
+        val uri = Uri.parse(contentUri)  // Parse the content URI
+        context.contentResolver.openInputStream(uri)  // Open InputStream using content resolver (콘텐츠 리졸버를 사용해 InputStream 열기)
+            ?: throw IllegalStateException("Failed to obtain InputStream")  // If InputStream is null, throw an exception
+    }
+}

--- a/data/src/main/java/com/ld5ehom/data/usecase/file/UploadImageUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/file/UploadImageUseCaseImpl.kt
@@ -1,0 +1,46 @@
+package com.ld5ehom.data.usecase.file
+
+import com.ld5ehom.data.retrofit.FileService
+import com.ld5ehom.data.retrofit.UriRequestBody
+import com.ld5ehom.domain.model.Image
+import com.ld5ehom.domain.usecase.file.GetInputStreamUseCase
+import com.ld5ehom.domain.usecase.file.UploadImageUseCase
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MultipartBody
+import javax.inject.Inject
+
+class UploadImageUseCaseImpl @Inject constructor(
+    private val fileService: FileService,  // Handles file upload to the server (파일을 서버에 업로드 처리)
+    private val getInputStreamUseCase: GetInputStreamUseCase,  // Retrieves input stream for the image file (이미지 파일의 입력 스트림을 가져옴)
+) : UploadImageUseCase {
+
+    // Invokes the use case to upload the image (이미지 업로드 유즈케이스 실행)
+    override suspend fun invoke(image: Image): Result<String> = kotlin.runCatching {
+        // Prepare the file name part for the multipart form (멀티파트 폼을 위한 파일 이름 준비)
+        val fileNamePart = MultipartBody.Part.createFormData(
+            "fileName",  // Key for the file name
+            image.name   // The actual file name
+        )
+
+        // Create the request body using the data/retrofit/UriRequestBody (UriRequestBody를 사용하여 요청 본문 생성)
+        val requestBody = UriRequestBody(
+            contentUri = image.uri,
+            getInputStreamUseCase = getInputStreamUseCase,  // Use case to get the input stream (입력 스트림을 가져오는 유즈케이스)
+            contentType = image.mimeType.toMediaType(),  // MIME type of the image (이미지의 MIME 타입)
+            contentLength = image.size    // buffer
+        )
+
+        // Prepare the file part for the multipart form (멀티파트 폼을 위한 파일 파트 준비)
+        val filePart = MultipartBody.Part.createFormData(
+            "file",
+            image.name,
+            requestBody  // The request body created earlier
+        )
+
+        // Upload the file using the file service and return the file path (파일 서비스를 사용하여 파일 업로드 후 파일 경로 반환)
+        fileService.uploadFile(
+            fileName = fileNamePart,
+            file = filePart
+        ).data.filePath  // Return the file path from the response (응답에서 파일 경로 반환)
+    }
+}

--- a/data/src/main/java/com/ld5ehom/data/usecase/main/profile/SetProfileImageUseCaseImpl.kt
+++ b/data/src/main/java/com/ld5ehom/data/usecase/main/profile/SetProfileImageUseCaseImpl.kt
@@ -1,0 +1,38 @@
+package com.ld5ehom.data.usecase.main.profile
+
+import com.ld5ehom.data.di.ld5ehom_HOST
+import com.ld5ehom.domain.model.Image
+import com.ld5ehom.domain.usecase.file.GetImageUseCase
+import com.ld5ehom.domain.usecase.file.UploadImageUseCase
+import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
+import com.ld5ehom.domain.usecase.main.profile.SetMyUserUseCase
+import com.ld5ehom.domain.usecase.main.profile.SetProfileImageUseCase
+import javax.inject.Inject
+
+class SetProfileImageUseCaseImpl @Inject constructor(
+    private val uploadImageUseCase: UploadImageUseCase,  // Handles image upload to the server (이미지 서버 업로드 처리)
+    private val getImageUseCase: GetImageUseCase,  // Retrieves image information from the content URI (콘텐츠 URI에서 이미지 정보 가져옴)
+    private val setMyUserUseCase: SetMyUserUseCase,  // Updates user profile information (사용자 프로필 정보 업데이트)
+    private val getMyUserUseCase: GetMyUserUseCase,  // Retrieves the current user information (현재 사용자 정보 가져옴)
+) : SetProfileImageUseCase {
+
+    // Executes the use case to update the user's profile image (사용자의 프로필 이미지를 업데이트하는 유즈케이스 실행)
+    override suspend fun invoke(contentUri: String): Result<Unit> = kotlin.runCatching {
+        // Step 1: Fetch the current user information (현재 사용자 정보 가져오기)
+        val user = getMyUserUseCase().getOrThrow()
+
+        // Step 2: Retrieve the image information from the provided content URI (제공된 콘텐츠 URI에서 이미지 정보 가져오기)
+        val image: Image = getImageUseCase(contentUri = contentUri)
+            ?: throw NullPointerException("Image not found")
+
+        // Step 3: Upload the image to the server and get the image path (이미지를 서버에 업로드하고 이미지 경로 가져오기)
+        val imagePath = uploadImageUseCase(
+            image
+        ).getOrThrow()
+
+        // Step 4: Update the user's profile with the new image URL (사용자의 프로필을 새 이미지 URL로 업데이트)
+        setMyUserUseCase(
+            profileImageUrl = "$ld5ehom_HOST/$imagePath"  // Host
+        ).getOrThrow()
+    }
+}

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,9 +1,15 @@
 plugins {
     id("java-library")
     alias(libs.plugins.jetbrains.kotlin.jvm)
+    alias(libs.plugins.kotlin.serialization)
 }
 
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+}
+
+dependencies {
+    // serialization
+    implementation(libs.kotlinx.serialization.json)
 }

--- a/domain/src/main/java/com/ld5ehom/domain/model/Image.kt
+++ b/domain/src/main/java/com/ld5ehom/domain/model/Image.kt
@@ -1,0 +1,12 @@
+package com.ld5ehom.domain.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+// Data class representing an image with its URI, name, size, and MIME type
+data class Image(
+    val uri: String,      // The URI of the image
+    val name: String,     // The file name of the image
+    val size: Long,       // The size of the image file in bytes
+    val mimeType: String  // The MIME type of the image (e.g., image/jpeg, image/png)
+)

--- a/domain/src/main/java/com/ld5ehom/domain/usecase/file/GetImageUseCase.kt
+++ b/domain/src/main/java/com/ld5ehom/domain/usecase/file/GetImageUseCase.kt
@@ -1,0 +1,9 @@
+package com.ld5ehom.domain.usecase.file
+
+import com.ld5ehom.domain.model.Image
+
+interface GetImageUseCase {
+    operator fun invoke(
+        contentUri: String
+    ): Image?
+}

--- a/domain/src/main/java/com/ld5ehom/domain/usecase/file/GetInputStreamUseCase.kt
+++ b/domain/src/main/java/com/ld5ehom/domain/usecase/file/GetInputStreamUseCase.kt
@@ -1,0 +1,9 @@
+package com.ld5ehom.domain.usecase.file
+
+import java.io.InputStream
+
+interface GetInputStreamUseCase {
+    operator fun invoke(
+        contentUri: String
+    ): Result<InputStream>
+}

--- a/domain/src/main/java/com/ld5ehom/domain/usecase/file/UploadImageUseCase.kt
+++ b/domain/src/main/java/com/ld5ehom/domain/usecase/file/UploadImageUseCase.kt
@@ -1,0 +1,9 @@
+package com.ld5ehom.domain.usecase.file
+
+import com.ld5ehom.domain.model.Image
+
+interface UploadImageUseCase {
+    suspend operator fun invoke(
+        image: Image
+    ): Result<String>
+}

--- a/domain/src/main/java/com/ld5ehom/domain/usecase/main/profile/SetProfileImageUseCase.kt
+++ b/domain/src/main/java/com/ld5ehom/domain/usecase/main/profile/SetProfileImageUseCase.kt
@@ -1,0 +1,10 @@
+package com.ld5ehom.domain.usecase.main.profile
+
+// Interface for setting the user's profile image
+// (사용자의 프로필 이미지를 설정하기 위한 인터페이스)
+interface SetProfileImageUseCase {
+    // Updates the profile image with the provided content URI (as a String)
+    // Note: Android's Uri class cannot be used directly in the domain layer, so the content URI is passed as a String.
+    // (참고: Android의 Uri 클래스는 도메인 계층에서 사용할 수 없으므로 content URI를 String으로 받음)
+    suspend operator fun invoke(contentUri:String):Result<Unit>
+}

--- a/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileScreen.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileScreen.kt
@@ -71,12 +71,26 @@ fun ProfileScreen(viewModel: ProfileViewModel = hiltViewModel()) {
         }
     }
 
+    // Sets up an activity result launcher for selecting a visual media (image) from the device gallery
+    // (기기 갤러리에서 이미지를 선택하기 위한 Activity Result 런처 설정)
+    val visualMediaPickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),  // Specifies the media type to pick (이미지 선택을 위한 계약)
+        onResult = viewModel::onImageChange  // Handles the result of the image selection (선택된 이미지를 처리)
+    )
+
+
     // Displays the user's Profiles screen with a profile image, username, and logout button
     // (프로필 이미지, 사용자 이름, 로그아웃 버튼을 포함한 설정 화면을 표시)
     ProfileScreen(
         username = state.username,
         profileImageUrl = state.profileImageUrl,
-        onImageChangeClick = {},
+        onImageChangeClick = {
+            visualMediaPickerLauncher.launch(
+                PickVisualMediaRequest(  // Limits the picker to image files only (이미지 파일만 선택할 수 있도록 제한)
+                    ActivityResultContracts.PickVisualMedia.ImageOnly
+                )
+            )
+        },
         onNameChangeClick = { usernameDialogVisible = true },
         onLogoutClick = viewModel::onLogoutClick
     )

--- a/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileViewModel.kt
+++ b/presentation/src/main/java/com/ld5ehom/presentation/main/profile/ProfileViewModel.kt
@@ -1,5 +1,6 @@
 package com.ld5ehom.presentation.main.profile
 
+import android.net.Uri
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -8,6 +9,7 @@ import com.ld5ehom.domain.model.User
 import com.ld5ehom.domain.usecase.login.ClearTokenUseCase
 import com.ld5ehom.domain.usecase.main.profile.GetMyUserUseCase
 import com.ld5ehom.domain.usecase.main.profile.SetMyUserUseCase
+import com.ld5ehom.domain.usecase.main.profile.SetProfileImageUseCase
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
@@ -31,6 +33,10 @@ class ProfileViewModel @Inject constructor(
     // Injected SetMyUserUseCase to update the current user's profile information
     // (현재 사용자의 프로필 정보를 업데이트하기 위한 SetMyUserUseCase 주입)
     private val setMyUserUseCase: SetMyUserUseCase,
+
+    // Injected SetProfileImageUseCase to handle the profile image update
+    // (프로필 이미지 업데이트를 처리하기 위한 SetProfileImageUseCase 주입)
+    private val setProfileImageUseCase: SetProfileImageUseCase
 ) : ViewModel(), ContainerHost<ProfileState, ProfileSideEffect> {
 
     // Container for managing state and side effects in Orbit MVI
@@ -79,10 +85,20 @@ class ProfileViewModel @Inject constructor(
     // Handles the username change by calling setMyUserUseCase to update the user's profile
     // (사용자의 프로필을 업데이트하기 위해 setMyUserUseCase를 호출하여 사용자 이름을 변경 처리함)
     fun onUsernameChange(username: String) = intent {
-        setMyUserUseCase(username = username).getOrThrow()   // Executes the use case to update the username and throws an exception if it fails
+        setMyUserUseCase(
+            username = username
+        ).getOrThrow()   // Executes the use case to update the username and throws an exception if it fails
         load()
     }
 
+    // Handles the profile image change by calling setProfileImageUseCase to update the user's profile image
+    // (사용자의 프로필 이미지를 업데이트하기 위해 setProfileImageUseCase를 호출하여 이미지 변경 처리함)
+    fun onImageChange(contentUri: Uri?) = intent {
+        setProfileImageUseCase(
+            contentUri = contentUri.toString()
+        ).getOrThrow()  // Executes the use case to update the profile image and throws an exception if it fails
+        load()
+    }
 }
 
 // Immutable state class to hold profile data


### PR DESCRIPTION
    - ProfileScreen Update : Image Change Feature Added - Integrated an image picker using rememberLauncherForActivityResult to allow users to select an image from their device. When the user clicks to change the profile image, the media picker is launched, limited to image files only. The selected image is then handled in the ViewModel's onImageChange function to update the profile picture.
    - ProfileViewModel Update : Profile Image Update Handling
      - The onImageChange function updates the user's profile image by calling setProfileImageUseCase and reloading the user's profile to reflect the changes.
    - SetProfileImageUseCase: Interface Definition and Domain Considerations - SetProfileImageUseCase defines a contract for updating the user's profile image using a content URI. - Since the Android Uri class is part of the Android framework and cannot be used in the domain layer, the content URI is passed as a String to maintain platform independence.
    - SetProfileImageUseCaseImpl: Image Upload Logic
      - The image upload flow involves fetching user information, retrieving image details from the URI, uploading the image to the server, and updating the profile with the new image URL.
    - Image Data Model : Serialization Dependency - In Android's Clean Architecture, data resides at the core of the application, and the architecture's dependency rule allows the outer layers (such as data or presentation) to depend on the inner core (domain). Hence, the Image class is placed in the domain layer, and rather than creating separate DTOs or UI models for the data and presentation layers, the same model is reused across the entire app to simplify code structure. - Kotlinx.serialization.json was added as a dependency to handle the serialization and deserialization of the Image data model into and from JSON. This enables seamless conversion of the Image data class for network communication and data persistence.
    - UploadImageUseCaseImpl: Uploading Images via FileService
      - The UploadImageUseCaseImpl class is responsible for uploading images to the server using FileService. It converts the image into multipart form data, including the file name and image file itself, and returns the file path of the uploaded image.
    - FileService : File Upload API - This API defines an interface for uploading files using multipart form data, including the file name and the file itself.
    - data/di/RetofitModule Update : FileService Binding
      - This update adds functionality for binding the FileService interface to Retrofit, enabling API calls for file uploads.
    - UriRequestBody : Handling Content Upload from URI - UriRequestBody is a custom RequestBody class used for uploading files from a content URI. It retrieves the input stream from the URI and writes it to a BufferedSink, handling multipart file uploads.
    - GetInputStreamUseCaseImpl: Fetching InputStream from Content URI
      - The GetInputStreamUseCaseImpl class implements the logic to retrieve an InputStream from a content URI using the Android content resolver. It returns the result wrapped in a Result object.
    - FileModule: Binding Use Cases to Interfaces - This module binds the implementations of GetInputStreamUseCase, GetImageUseCase, and UploadImageUseCase to their respective interfaces. These bindings are installed in a SingletonComponent.
    - GetImageUseCaseImpl: Retrieving Image Metadata from URI
      - The GetImageUseCaseImpl class is responsible for retrieving metadata, such as the image name, size, and MIME type, from a content URI using the content resolver. It returns an Image object with the gathered information.